### PR TITLE
feat: Add migration to migrate existing data to new member table

### DIFF
--- a/database/migrations/1772419448503-add-data.ts
+++ b/database/migrations/1772419448503-add-data.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddData1772419448503 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`INSERT INTO "Member"(id, userid, name,displayname, proxy, propic, "createdAt", "updatedAt") SELECT id,userid, name,displayname, proxy, propic, "createdAt", "updatedAt" FROM "Members";`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`TRUNCATE TABLE "Member"`);
+    }
+}


### PR DESCRIPTION
The postgres `.dump` file has a table with a bunch of data that needs to be transferred over to the new table. This adds a migration to do this.