### PR TITLE
fix: update message helper reference hotfix

### DIFF
--- a/database/data-source.ts
+++ b/database/data-source.ts
@@ -13,7 +13,7 @@ export const AppDataSource = new DataSource({
     password: process.env.POSTGRES_PASSWORD,
     database: "postgres",
     synchronize: false,
-    logging: true,
+    logging: false,
     entities: [path.join(__dirname, "./entity/*.{ts,js}")],
     migrations: [path.join(__dirname, "./migrations/*.{ts,js}")],
     migrationsRun: true,

--- a/src/helpers/messageHelper.js
+++ b/src/helpers/messageHelper.js
@@ -1,4 +1,4 @@
-const {memberHelper} = require('./memberHelper.js');
+const {memberRepo} = require('../repositories/memberRepo.js');
 
 const msgh = {};
 
@@ -39,7 +39,7 @@ msgh.parseCommandArgs = function(content, commandName) {
  * @returns {Promise<{model, string, bool}>} The proxy message object.
  */
 msgh.parseProxyTags = async function (authorId, content, attachmentUrl = null){
-    const members = await memberHelper.getMembersByAuthor(authorId);
+    const members = await memberRepo.getMembersByAuthor(authorId);
     // If an author has no members, no sense in searching for proxy
     if (members.length === 0) {
         return;

--- a/tests/helpers/messageHelper.test.js
+++ b/tests/helpers/messageHelper.test.js
@@ -2,16 +2,16 @@ const env = require('dotenv');
 env.config();
 
 
-jest.mock('../../src/helpers/memberHelper.js', () => {
+jest.mock('../../src/repositories/memberRepo.js', () => {
     return {
-        memberHelper: {
+        memberRepo: {
             getMembersByAuthor: jest.fn()
         }
     }
 })
 
-const {memberHelper} = require("../../src/helpers/memberHelper.js");
 const {messageHelper} = require("../../src/helpers/messageHelper.js");
+const {memberRepo} = require("../../src/repositories/memberRepo");
 
 describe('messageHelper', () => {
 
@@ -54,7 +54,7 @@ describe('messageHelper', () => {
         const attachmentUrl = "../oya.png"
 
         beforeEach(() => {
-            memberHelper.getMembersByAuthor = jest.fn().mockImplementation((specificAuthorId) => {
+            memberRepo.getMembersByAuthor = jest.fn().mockImplementation((specificAuthorId) => {
                 if (specificAuthorId === "1") return membersFor1;
                 if (specificAuthorId === "2") return membersFor2;
                 if (specificAuthorId === "3") return membersFor3;


### PR DESCRIPTION
I forgot to update a reference in messageHelper to memberRepo instead of memberHelper. This was causing errors on every message. Locally tested seems to fix things.