### PR TITLE
fix: update dockerfile to run npm start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ FROM node:20-alpine
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY . .
-CMD ["node", "src/bot.js"]
+CMD ["npm", "start"]


### PR DESCRIPTION
Previously the DOCKERFILE was running `node src/bot.js` which was erroring when I mixed the database `.ts` models in. I changed it so that it runs `npm start`, which has a script already to run `ts-node` instead of `node`.