### PR TITLE
fix: changed property reference for createMember in repo

### DIFF
--- a/src/repositories/memberRepo.js
+++ b/src/repositories/memberRepo.js
@@ -54,7 +54,7 @@ memberRepo.removeMember = async function (authorId, memberName) {
  */
 memberRepo.createMember = async function (createObj) {
     return members.insert({
-        name: createObj.name, userid: createObj.authorId, displayname: createObj.displayName, proxy: createObj.proxy, propic: createObj.propic
+        name: createObj.name, userid: createObj.userid, displayname: createObj.displayname, proxy: createObj.proxy, propic: createObj.propic
     });
 }
 


### PR DESCRIPTION
I was referencing properties that don't exist in the object I was passing in, this is fixed now.